### PR TITLE
Make sure the url starts with cookie-wall instead of anywhere

### DIFF
--- a/admin/settings-template.php
+++ b/admin/settings-template.php
@@ -1,8 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-include_once( plugin_dir_path( __DIR__ ) . 'includes/functions.php' );
-
 $plugin_admin_path      = plugin_dir_path( __FILE__ );
 $nginx_config_path      = $plugin_admin_path . 'config_files/nginx.conf';
 $apache_config_path     = $plugin_admin_path . 'config_files/.htaccess';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -21,3 +21,21 @@ function llcw_read_config_file( $path ){
     }
     return '';
 }
+
+/**
+ * Determine if a given string starts with a given substring.
+ *
+ * @param string       $haystack
+ * @param string|array $needles
+ *
+ * @return bool
+ */
+function llcw_starts_with( $haystack, $needles ) {
+	foreach ( (array) $needles as $needle ) {
+		if ( $needle != '' && strpos( $haystack, $needle ) === 0 ) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/ll-cookie-wall.php
+++ b/ll-cookie-wall.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class LL_Cookie_Wall {
 	public function __construct() {
+		include_once( plugin_dir_path( __FILE__ ) . 'includes/functions.php' );
 		load_plugin_textdomain( 'll-cookie-wall', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
 		add_action('init', array($this, 'plugin_init'));

--- a/public/public-cookie-wall.php
+++ b/public/public-cookie-wall.php
@@ -71,15 +71,16 @@ class Public_Cookie_Wall {
 	}
 
 	/**
-	 * Check if we are on the custom rewrite rule and load the Cookie Wall template
+	 * Check if we are on the custom rewrite rule and load the Cookie Wall template.
 	 */
-	public function custom_parse_request( &$wp) {
-		if( isset( $wp->request ) ) {
-			if ( strpos( $wp->request, 'cookie-wall' ) !== false || strpos( $wp->request, 'cookie_wall' ) !== false ) {
+	public function custom_parse_request( &$wp ) {
+		if ( isset( $wp->request ) ) {
+			if ( llcw_starts_with( $wp->request, [ 'cookie-wall', 'cookie_wall' ] ) ) {
 				include plugin_dir_path( __FILE__ ) . 'template-cookie-wall.php';
 				exit();
 			}
 		}
+
 		return;
 	}
 


### PR DESCRIPTION
This makes sure that if you write a post with cookie-wall in the slug the cookie wall is not injected (unless you had not accepted ofcourse).